### PR TITLE
Use environment API_KEY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM python:3.10-slim
 
 WORKDIR /app
 
+# Allow passing API_KEY during build
+ARG API_KEY
+ENV API_KEY=${API_KEY}
+
 # Copy requirements first to leverage Docker cache
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Document Parsing Application
+
+This Flask application parses documents using the RunPulse API. It requires an API key which is supplied via the `API_KEY` environment variable.
+
+## Quick Start
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Export your API key before launching the app:
+   ```bash
+   export API_KEY=<your-key>
+   python app/app.py
+   ```
+
+## Docker
+
+The Docker image expects the `API_KEY` environment variable at runtime. Example:
+
+```bash
+docker build -t document-parser .
+docker run -e API_KEY=<your-key> -p 5000:5000 document-parser
+```
+
+Alternatively, you can pass the key during build:
+
+```bash
+docker build --build-arg API_KEY=<your-key> -t document-parser .
+```
+
+## Tests
+
+The tests require the `API_KEY` variable as well. It is set automatically within the test suite, so running
+
+```bash
+pytest
+```
+
+should work without additional configuration.

--- a/app/app.py
+++ b/app/app.py
@@ -20,7 +20,9 @@ app.config['ALLOWED_EXTENSIONS'] = {'pdf', 'docx', 'doc', 'txt', 'csv', 'xls', '
 os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
 
 # API key from environment
-API_KEY = "rOMPNDmLDkgqFXtsySPU9LJX8fjJ78q4aF5OMZBj"
+API_KEY = os.getenv('API_KEY')
+if not API_KEY:
+    raise EnvironmentError('API_KEY environment variable not set')
 
 def allowed_file(filename):
     return '.' in filename and \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,6 @@ services:
       - "5000:5000"
     volumes:
       - ./app:/app
+    environment:
+      - API_KEY=${API_KEY}
     restart: always

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,8 @@
 # Start the Flask application
 cd /home/ubuntu/deployment/app
 export PYTHONPATH=/home/ubuntu/deployment/lib:$PYTHONPATH
+if [ -z "$API_KEY" ]; then
+  echo "API_KEY environment variable not set" >&2
+  exit 1
+fi
 python3 app.py

--- a/setup_service.sh
+++ b/setup_service.sh
@@ -13,6 +13,7 @@ After=network.target
 User=ubuntu
 WorkingDirectory=/home/ubuntu/deployment/app
 Environment="PYTHONPATH=/home/ubuntu/deployment/lib"
+Environment="API_KEY=${API_KEY}"
 ExecStart=/usr/bin/python3 /home/ubuntu/deployment/app/app.py
 Restart=always
 

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,10 @@
+import importlib
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+def test_api_key_loaded(monkeypatch):
+    monkeypatch.setenv('API_KEY', 'dummy-key')
+    module = importlib.reload(importlib.import_module('app.app'))
+    assert module.API_KEY == 'dummy-key'


### PR DESCRIPTION
## Summary
- load API_KEY from environment in app
- expect API_KEY variable in run scripts and Docker setup
- provide docker-compose env config
- add basic pytest verifying API_KEY usage
- document API_KEY setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e74757d083228be762359748eab3