### PR TITLE
Add Flask tests and CI workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+from .app import app

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask==3.1.0
 markdown==3.8
 requests==2.32.3
 werkzeug==3.1.3
+pytest==8.3.5

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import importlib
+import io
+import json
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import app as flask_app
+app_module = importlib.import_module("app.app")
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    flask_app.config["TESTING"] = True
+    flask_app.config["UPLOAD_FOLDER"] = str(tmp_path / "uploads")
+    os.makedirs(flask_app.config["UPLOAD_FOLDER"], exist_ok=True)
+    monkeypatch.chdir(tmp_path)
+    with flask_app.test_client() as client:
+        yield client
+
+def test_index_route(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b'Document Parsing App' in response.data
+
+def test_upload_file_success(client, monkeypatch):
+    def fake_process_file(path):
+        return {'message': 'ok'}
+    monkeypatch.setattr(app_module, 'process_file', fake_process_file)
+    data = {'file': (io.BytesIO(b'hello'), 'sample.txt')}
+    response = client.post('/upload', data=data, content_type='multipart/form-data')
+    assert response.status_code == 200
+    assert response.get_json() == {'message': 'ok'}
+    with open('result.json') as f:
+        assert json.load(f) == {'message': 'ok'}
+
+def test_upload_disallowed_file(client):
+    data = {'file': (io.BytesIO(b'hello'), 'sample.exe')}
+    response = client.post('/upload', data=data, content_type='multipart/form-data')
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- add pytest to requirements
- create simple route tests
- expose Flask app module
- add GitHub Actions workflow to run pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e783aee4832294e4e4f241a3304d