### PR TITLE
Add Vercel serverless handler

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+# Add the project root to Python path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from app.app import app as flask_app
+
+def handler(environ, start_response):
+    return flask_app(environ, start_response)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+from .app import app

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
-  "functions": { "api/index.py": { "runtime": "python@3.10" } },
+  "functions": { "api/index.py": { "runtime": "python3.10" } },
   "routes": [{ "src": "/(.*)", "dest": "api/index.py" }]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "functions": { "api/index.py": { "runtime": "python@3.10" } },
+  "routes": [{ "src": "/(.*)", "dest": "api/index.py" }]
+}


### PR DESCRIPTION
## Summary
- add API entrypoint for Vercel
- expose app package
- add `vercel.json` to route traffic to the serverless handler
- specify Python runtime version for Vercel

## Testing
- `python -m py_compile api/index.py app/__init__.py app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6853e3cb5ac0832289259ccdef330a20