### PR TITLE
Fix vercel runtime config and stabilize tests

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -6,8 +6,12 @@ import json
 import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from app import app as flask_app
+
+# Ensure API_KEY is available before importing the application
+os.environ.setdefault("API_KEY", "dummy-key")
+
 app_module = importlib.import_module("app.app")
+flask_app = app_module.app
 
 @pytest.fixture()
 def client(tmp_path, monkeypatch):

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
-  "functions": { "api/index.py": { "runtime": "python3.10" } },
+  "functions": { "api/index.py": { "runtime": "vercel-python@4.7.2" } },
   "routes": [{ "src": "/(.*)", "dest": "api/index.py" }]
 }


### PR DESCRIPTION
## Summary
- set `vercel-python@4.7.2` as the runtime in `vercel.json`
- make tests set a dummy `API_KEY` before importing the Flask app

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685494b356b88322b73e9df1437e23c8