### PR TITLE
Fix Vercel runtime config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
-  "functions": { "api/index.py": { "runtime": "vercel-python@4.7.2" } },
-  "routes": [{ "src": "/(.*)", "dest": "api/index.py" }]
+  "functions": {
+    "api/index.py": {
+      "runtime": "python3.10"
+    }
+  },
+  "routes": [
+    { "src": "/(.*)", "dest": "api/index.py" }
+  ]
 }


### PR DESCRIPTION
## Summary
- specify a valid Vercel runtime using `python3.10`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685542ed04f883229ced831b036af16e